### PR TITLE
Simplify package.json and vite config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "kirby-vite",
   "version": "1.0.0",
   "scripts": {
-    "dev": "touch src/.lock && APP_ENV=development vite",
-    "build": "touch src/.lock && rm src/.lock && APP_ENV=production vite build"
+    "dev": "touch src/.lock && vite",
+    "build": "rm -f src/.lock && vite build"
   },
   "devDependencies": {
     "sass": "^1.32.6",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,14 +1,14 @@
+import { resolve } from 'path'
 import liveReload from 'vite-plugin-live-reload'
-const { resolve } = require('path')
 
-export default {
+export default ({ command, mode }) => ({
   plugins: [
-    liveReload(__dirname+'/site/**/*.php')
+    liveReload('site/**/*.php')
   ],
   root: 'src',
-  base: process.env.APP_ENV === 'development' ? '/' : '/dist/',
+  base: mode === 'development' ? '/' : '/dist/',
   build: {
-    outDir: resolve(__dirname, 'public/dist'),
+    outDir: resolve(process.cwd(), 'public/dist'),
     emptyOutDir: true,
     manifest: true,
     target: 'es2018',
@@ -21,5 +21,5 @@ export default {
       port: 3000
     },
   }
-}
+})
 


### PR DESCRIPTION
Hey there!

Great work. I have some suggestions mainly to simplify scripts:

- `APP_ENV` can be substituted with Vite's `mode` key – available when export not an config object but an config funciotn
- `__dirname` isn't available in type module Node projects (which I always use), therefore use `process.cwd()`
- force deletion of `.lock` file, don't create it every time the app is built

Hope those changes appeal to you.